### PR TITLE
Ios andrid build script fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,9 +49,6 @@ TESTFAIRY_PLUGIN_URL = "https://github.com/testfairy/testfairy-cordova-plugin"
 TESTFAIRY_PLUGIN_NAME = "com.testfairy.cordova-plugin"
 LOCK_FILE="#{CORDOVA_PATH}/.ios_build.lock"
 LOCK_FILE_MAX_AGE = 1000 # number of seconds before we remove lock file if failing build
-SIGNING_DETAILS= "iPhone Distribution: Crossroads Foundation Limited (6B8FS8W94M)"
-PROVISONING_PROFILE ="#{ROOT_PATH}/GoodCityStore.mobileprovision"
-
 # Default task
 task default: %w(app:build)
 
@@ -93,6 +90,8 @@ namespace :ember do
   end
   desc "Ember build with Cordova enabled"
   task :build do
+    # Before starting Ember build clean up folders
+    Rake::Task["clobber"].invoke
     Dir.chdir(ROOT_PATH) do
       system({"EMBER_CLI_CORDOVA" => "1", "APP_SHA" => app_sha, "APP_SHARED_SHA" => app_shared_sha, "staging" => is_staging}, "#{EMBER} build --environment=production")
     end
@@ -109,30 +108,29 @@ namespace :cordova do
   end
   desc "Cordova prepare {platform}"
   task :prepare do
-    FileUtils.mkdir_p "#{ROOT_PATH}/dist"
+    # Before cordova prepare build ember app that will auto update the dist folder too
+    Rake::Task["ember:build"].invoke
     sh %{ ln -s "#{ROOT_PATH}/dist" "#{CORDOVA_PATH}/www" } unless File.exists?("#{CORDOVA_PATH}/www")
-    log("Preparing app...")
     build_details.map{|key, value| log("#{key.upcase}: #{value}")}
+
+    log("Preparing app for...#{platform}")
     Dir.chdir(CORDOVA_PATH) do
       system({"ENVIRONMENT" => environment}, "cordova prepare #{platform}")
-    end
-    if platform == "ios"
-      Dir.chdir(CORDOVA_PATH) do
+
+      if platform == "ios"
         sh %{ cordova plugin add #{TESTFAIRY_PLUGIN_URL} } if environment == "staging"
         sh %{ cordova plugin remove #{TESTFAIRY_PLUGIN_NAME}; true } if environment == "production"
       end
     end
   end
+
   desc "Cordova build {platform}"
-  task :build do
-    if platform == "ios"
-      Dir.chdir(CORDOVA_PATH) do
-        system({"ENVIRONMENT" => environment}, "cordova compile #{platform} --release --device")
-        sh %{ xcrun -sdk iphoneos PackageApplication -v '#{app_file}' -o '#{ipa_file}' --sign "#{app_signing_identity}" --embed "#{app_provision_profile}"}
-      end
-    else
-      Dir.chdir(ROOT_PATH) do
-        system({"EMBER_CLI_CORDOVA" => "1", "APP_SHA" => app_sha, "APP_SHARED_SHA" => app_shared_sha, "staging" => is_staging}, "#{EMBER} cordova:compile --platform #{platform} --environment=#{environment}")
+  task build: :prepare do
+    Dir.chdir(CORDOVA_PATH) do
+      log("environment is #{environment}")
+      system({"ENVIRONMENT" => environment}, "cordova compile #{platform} --release --device")
+      if platform == "ios"
+        sh %{ xcrun -sdk iphoneos PackageApplication -v '#{app_file}' -o '#{ipa_file}' --sign "#{app_signing_identity}"}
       end
     end
     # Copy build artifacts
@@ -286,10 +284,6 @@ def app_signing_identity
   app_details[environment]["signing_detail"]
 end
 
-def app_provision_profile
-  "#{ROOT_PATH}/#{app_details[environment]["provision_profile"]}"
-end
-
 def app_details
   @app_details ||= JSON.parse(File.read(APP_DETAILS_PATH))
 end
@@ -311,8 +305,7 @@ end
 def build_details
   {
     app_name: app_name, env: environment, platform: platform,
-    app_version: app_version, app_signing_identity: app_signing_identity,
-    app_provision_profile: app_provision_profile
+    app_version: app_version, app_signing_identity: app_signing_identity
   }
 end
 

--- a/cordova/appDetails.json
+++ b/cordova/appDetails.json
@@ -2,11 +2,13 @@
   "staging": {
     "name": "S. GoodCity",
     "url": "hk.goodcity.appstaging",
-    "version": "0.3.60"
+    "version": "0.3.60",
+    "signing_detail": "iPhone Distribution: Crossroads Foundation Limited (6B8FS8W94M)"
   },
   "production": {
     "name": "GoodCity",
     "url": "hk.goodcity.app",
-    "version": "0.3.0"
+    "version": "0.3.0",
+    "signing_detail": "iPhone Distribution: Crossroads Foundation Limited (6B8FS8W94M)"
   }
 }

--- a/cordova/scripts/prepareConfigXml.js
+++ b/cordova/scripts/prepareConfigXml.js
@@ -3,35 +3,35 @@
 // ENVIRONMENT=production cordova prepare android
 
 module.exports = function(context) {
-    var fs = require('fs');
-    var xml2js = require('xml2js');
-    var path = require('path');
-    var rootdir = context["opts"]["projectRoot"];
-    var environment = "staging";
-    if (process.env.ENVIRONMENT) { environment = process.env.ENVIRONMENT }
+  var fs = require('fs');
+  var xml2js = require('xml2js');
+  var path = require('path');
+  var rootdir = context["opts"]["projectRoot"];
+  var environment = "staging";
+  if (process.env.ENVIRONMENT) { environment = process.env.ENVIRONMENT }
 
-    if (rootdir) {
-        var app_details_path = path.join(rootdir, "appDetails.json");
-        var app_details = JSON.parse(fs.readFileSync(app_details_path, 'utf8'));
-        config_xml_path = path.join(rootdir, "config.xml");
-        if (fs.existsSync(config_xml_path)) {
-            var parser = new xml2js.Parser();
-            fs.readFile(config_xml_path, 'utf8', function(err, xmlStr) {
+  if (rootdir) {
+      var app_details_path = path.join(rootdir, "appDetails.json");
+      var app_details = JSON.parse(fs.readFileSync(app_details_path, 'utf8'));
+      config_xml_path = path.join(rootdir, "config.xml");
+      if (fs.existsSync(config_xml_path)) {
+        var parser = new xml2js.Parser();
+        fs.readFile(config_xml_path, 'utf8', function(err, xmlStr) {
+            if (err) throw err;
+            parser.parseString(xmlStr, function (err, result) {
                 if (err) throw err;
-                parser.parseString(xmlStr, function (err, result) {
-                    if (err) throw err;
-                    result.widget.name = app_details[environment].name;
-                    result.widget.$.id = app_details[environment].url;
-                    result.widget.$.version = app_details[environment].version;
-                    var builder = new xml2js.Builder();
-                    var xml = builder.buildObject(result);
-                    fs.writeFileSync(config_xml_path, xml, 'utf8');
-                });
+                result.widget.name = app_details[environment].name;
+                result.widget.$.id = app_details[environment].url;
+                result.widget.$.version = app_details[environment].version;
+                var builder = new xml2js.Builder();
+                var xml = builder.buildObject(result);
+                fs.writeFileSync(config_xml_path, xml, 'utf8');
             });
-        } else {
-            console.log("Missing file:" + config_xml_path);
-        }
-    } else {
-        console.log("Can't find config files... aborting");
-    }
+        });
+      } else {
+        console.log("Missing file:" + config_xml_path);
+      }
+  } else {
+    console.log("Can't find config files... aborting");
+  }
 }


### PR DESCRIPTION
Modified script to make sure cordova:build happens only once `ember build` is called before prepare
all old folders like dist, cordova - plugins, platforms and www gets deleted before final cordova build
