### PR TITLE
PhoneGap push plugin fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,10 +328,10 @@ workflows:
             filters:
               branches:
                 only: /^(master|live)$/
-        # - ios_build_and_deploy:
-        #     requires:
-        #       - tests
-        #     filters:
-        #       branches:
-        #         only: /^(master|live)$/
+        - ios_build_and_deploy:
+            requires:
+              - tests
+            filters:
+              branches:
+                only: /^(master|live)$/
 

--- a/Rakefile
+++ b/Rakefile
@@ -113,6 +113,12 @@ namespace :cordova do
   desc "Cordova build {platform}"
   task build: :prepare do
     Dir.chdir(CORDOVA_PATH) do
+      #Temporary fix for phonegap-plugin-push
+      if platform == 'android'
+        sh %{ cordova plugin add phonegap-plugin-push@2.1.2 }
+      else
+        sh %{ cordova plugin add phonegap-plugin-push@1.9.2 --variable SENDER_ID="XXXXXXX" }
+      end
       build = (environment == "staging" && platform == 'android') ? "debug" : "release"
       extra_params = (platform === "android") ? '' : ios_build_config
       system({"ENVIRONMENT" => environment}, "cordova compile #{platform} --#{build} --device #{extra_params}")

--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -87,7 +87,6 @@
   <engine name="ios" spec="https://github.com/apache/cordova-ios.git#4.5.5" />
   <engine name="android" spec="~6.3.0"/>
   <engine name="windows" spec="~4.3.1"/>
-  <plugin name="phonegap-plugin-push" spec="~2.1.2"/>
   <plugin name="cordova-plugin-statusbar" spec="~2.1.1"/>
   <plugin name="cordova-plugin-device" spec="~1.1.1"/>
   <plugin name="cordova-plugin-whitelist" spec="~1.2.1"/>


### PR DESCRIPTION
Hi Team,

This PR fixes issue of iOS build for new push plugin version.
- It installs `1.9.2` v of `phonegap-plugin-push` for iOS
- `2.1.2` for Android

Please review it and let me know if any changes are required.
Thanks