### PR TITLE
GCW-2260- iTunes rejection fix

### DIFF
--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -67,15 +67,18 @@
     </feature>
     <preference name="Orientation" value="portrait"/>
     <preference name="Fullscreen" value="true"/>
-    <edit-config target="NSCameraUsageDescription" file="*-Info.plist" mode="merge">
+    <preference name="CAMERA_USAGE_DESCRIPTION" default=" " />
+    <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
         <string>So you can photograph items for donation.</string>
-    </edit-config>
-    <edit-config target="NSPhotoLibraryUsageDescription" file="*-Info.plist" mode="merge">
+    </config-file>
+    <preference name="PHOTOLIBRARY_USAGE_DESCRIPTION" default=" " />
+    <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
         <string>Needs photo library access to get photos from there</string>
-    </edit-config>
-    <edit-config target="NSPhotoLibraryAddUsageDescription" file="*-Info.plist" mode="merge">
+    </config-file>
+    <preference name="PHOTOLIBRARY_ADD_USAGE_DESCRIPTION" default=" " />
+    <config-file target="*-Info.plist" parent="NSPhotoLibraryAddUsageDescription">
         <string>Needs photo library access to save photos</string>
-    </edit-config>
+    </config-file>
   </platform>
   <access origin="*"/>
   <allow-intent href="https://maps.google.com/*"/>


### PR DESCRIPTION
Hi Team,
This PR is for iTunes rejection of iOS due to **Missing Purpose String in Info.plist File**. https://jira.crossroads.org.hk/browse/GCW-2260. I have added the fix. 
Please review the PR and let me know if any change is required. 
Thanks