### PR TITLE
redirect to login without showing the modal

### DIFF
--- a/tests/acceptance/authorization-test.js
+++ b/tests/acceptance/authorization-test.js
@@ -33,11 +33,6 @@ testSkip("Rediect to login if not logged-in", function() {
   visit("/offers");
 
   andThen(function() {
-    equal(Ember.$.trim(Ember.$("#messageBoxText").text()), t("must_login").toString());
-    okClick();
-  });
-
-  andThen(function() {
     equal(currentURL(), '/login');
   });
 });


### PR DESCRIPTION
Changes are mostly in shared.goodcity, this PR is to fix one test which expects the modal to be shown.. which will not be shown, because it has been removed in shared.goodcity.