### PR TITLE
Upgrade app to latest shared commit and fix offer load

### DIFF
--- a/app/routes/offers/index.js
+++ b/app/routes/offers/index.js
@@ -2,6 +2,10 @@ import AuthorizeRoute from "./../authorize";
 
 export default AuthorizeRoute.extend({
   model() {
+    let cachedRecords = this.store.peekAll("offer");
+    if (cachedRecords.get("length")) {
+      return Ember.RSVP.resolve(cachedRecords);
+    }
     return this.store.findAll("offer");
   },
 

--- a/app/routes/offers/index.js
+++ b/app/routes/offers/index.js
@@ -1,22 +1,23 @@
-import AuthorizeRoute from './../authorize';
+import AuthorizeRoute from "./../authorize";
 
 export default AuthorizeRoute.extend({
-
   model() {
-    return this.store.peekAll('offer');
+    return this.store.findAll("offer");
   },
 
   redirect(my_offers) {
     var route = this;
-    switch(my_offers.get('length')) {
-      case 0 : route.transitionTo('offers.new'); break;
-      case 1 :
-        if(my_offers.get('firstObject.state') === 'draft') {
-          var firstOffer = my_offers.get('firstObject');
-          if(firstOffer.get('itemCount') === 0) {
-            route.transitionTo('offer', firstOffer);
+    switch (my_offers.get("length")) {
+      case 0:
+        route.transitionTo("offers.new");
+        break;
+      case 1:
+        if (my_offers.get("firstObject.state") === "draft") {
+          var firstOffer = my_offers.get("firstObject");
+          if (firstOffer.get("itemCount") === 0) {
+            route.transitionTo("offer", firstOffer);
           } else {
-            route.transitionTo('offer.offer_details', firstOffer);
+            route.transitionTo("offer.offer_details", firstOffer);
           }
         }
     }
@@ -24,11 +25,10 @@ export default AuthorizeRoute.extend({
 
   renderTemplate() {
     this.render(); // default template
-    this.render('appMenuList', {
-      into: 'offers/index',
-      outlet: 'appMenuList',
-      controller: 'application'
+    this.render("appMenuList", {
+      into: "offers/index",
+      outlet: "appMenuList",
+      controller: "application"
     });
   }
-
 });

--- a/app/routes/offers/index.js
+++ b/app/routes/offers/index.js
@@ -4,7 +4,7 @@ export default AuthorizeRoute.extend({
   model() {
     let cachedRecords = this.store.peekAll("offer");
     if (cachedRecords.get("length")) {
-      return Ember.RSVP.resolve(cachedRecords);
+      return cachedRecords;
     }
     return this.store.findAll("offer");
   },

--- a/app/templates/offer/submit.hbs
+++ b/app/templates/offer/submit.hbs
@@ -26,7 +26,7 @@
       {{#online-button action="submitOffer" tagName="button" actionArgs=false classNames="button expand secondary"}}{{t "no"}}{{/online-button}}
     </div>
     <div class="small-6 columns">
-      {{#online-button action="submitOffer" actionArgs=true classNames="button expand"}}{{t "yes"}}{{/online-button}}
+      {{#online-button action="submitOffer" actionArgs=true classNames="button expand submit"}}{{t "yes"}}{{/online-button}}
     </div>
   </div>
 </div>

--- a/tests/acceptance/create-offer-test.js
+++ b/tests/acceptance/create-offer-test.js
@@ -1,22 +1,23 @@
-import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import { make } from 'ember-data-factory-guy';
-import TestHelper from 'ember-data-factory-guy/factory-guy-test-helper';
-import { module, test } from 'qunit';
+import Ember from "ember";
+import startApp from "../helpers/start-app";
+import { make } from "ember-data-factory-guy";
+import TestHelper from "ember-data-factory-guy/factory-guy-test-helper";
+import { module, test } from "qunit";
 // import { mockFindAll } from 'ember-data-factory-guy';
-
 
 var App, container;
 
-module('Create New Offer', {
+module("Create New Offer", {
   beforeEach: function() {
     App = startApp({}, 2);
     container = App.__container__;
     TestHelper.setup();
   },
   afterEach: function() {
-    Em.run(function() { TestHelper.teardown(); });
-    Ember.run(App, 'destroy');
+    Em.run(function() {
+      TestHelper.teardown();
+    });
+    Ember.run(App, "destroy");
   }
 });
 
@@ -29,13 +30,19 @@ test("should create new offer", function(assert) {
 
   andThen(function() {
     // test: created new offer and redirected to its show page.
-    assert.equal(currentURL(), '/offers/2');
+    assert.equal(currentURL(), "/offers/3");
 
     //test: item count zero
-    assert.equal($.trim(find('.tab-bar-section .title').text()), "Offer items (0)");
+    assert.equal(
+      $.trim(find(".tab-bar-section .title").text()),
+      "Offer items (0)"
+    );
 
     //test: no items message
-    assert.equal($.trim($('.no-items').text()), "You don't have any items in this offer yet. Please add your first item!");
+    assert.equal(
+      $.trim($(".no-items").text()),
+      "You don't have any items in this offer yet. Please add your first item!"
+    );
   });
 });
 
@@ -43,29 +50,39 @@ test("should redirect to previous empty offer", function(assert) {
   assert.expect(4);
 
   var currentUserId = JSON.parse(window.localStorage.currentUserId);
-  var user = make("user", {id:currentUserId});
-  make("offer_with_items", {id:1, createdBy:user}); // check offer with items is not returned
-  make("offer",{"id":5, createdBy:user});
+  var user = make("user", { id: currentUserId });
+  make("offer_with_items", { id: 1, createdBy: user }); // check offer with items is not returned
+  make("offer", { id: 5, createdBy: user });
 
-  container.lookup("service:messageBox").custom = (message, btn1Text, btn1Callback) => {
+  container.lookup("service:messageBox").custom = (
+    message,
+    btn1Text,
+    btn1Callback
+  ) => {
     btn1Callback();
   };
 
   visit("/offers");
 
   andThen(function() {
-    assert.equal(currentURL(), '/offers');
+    assert.equal(currentURL(), "/offers");
 
     click("a:contains('Make a New Donation')");
 
-    andThen(function(){
-      assert.equal(currentURL(), '/offers/5');
+    andThen(function() {
+      assert.equal(currentURL(), "/offers/5");
 
       //test: item count zero
-      assert.equal($.trim(find('.tab-bar-section .title').text()), "Offer items (0)");
+      assert.equal(
+        $.trim(find(".tab-bar-section .title").text()),
+        "Offer items (0)"
+      );
 
       //test: no items message
-      assert.equal($.trim(find('.no-items').text()), "You don't have any items in this offer yet. Please add your first item!");
+      assert.equal(
+        $.trim(find(".no-items").text()),
+        "You don't have any items in this offer yet. Please add your first item!"
+      );
     });
   });
 });

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -1,45 +1,48 @@
-import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import FactoryGuy from 'ember-data-factory-guy';
-import TestHelper from 'ember-data-factory-guy/factory-guy-test-helper';
-import '../factories/user_profile';
-import { module, test } from 'qunit';
+import Ember from "ember";
+import startApp from "../helpers/start-app";
+import FactoryGuy from "ember-data-factory-guy";
+import TestHelper from "ember-data-factory-guy/factory-guy-test-helper";
+import "../factories/user_profile";
+import { module, test } from "qunit";
 
 var App, hk_user, non_hk_user;
 
-module('Acceptance: Login', {
+module("Acceptance: Login", {
   beforeEach: function() {
     App = startApp();
     TestHelper.setup();
 
-    hk_user = FactoryGuy.make('with_hk_mobile');
-    non_hk_user = FactoryGuy.make('with_non_hk_mobile');
+    hk_user = FactoryGuy.make("with_hk_mobile");
+    non_hk_user = FactoryGuy.make("with_non_hk_mobile");
 
     App.__container__.lookup("controller:subscriptions").pusher = {
-      get: function() { return {}; },
+      get: function() {
+        return {};
+      },
       wire: function() {}
     };
   },
   afterEach: function() {
-    Ember.run(function () { TestHelper.teardown(); });
-    Ember.run(App, 'destroy');
+    Ember.run(function() {
+      TestHelper.teardown();
+    });
+    Ember.run(App, "destroy");
   }
 });
 
 test("User able to enter mobile number and get the sms code", function(assert) {
   assert.expect(1);
-
   visit("/login");
   andThen(function() {
     var ele_logout = $("a:contains('Logout')");
-    if(ele_logout.length > 0){
+    if (ele_logout.length > 0) {
       click(ele_logout[0]);
     }
   });
 
   andThen(function() {
-    fillIn('#mobile', hk_user.get("mobile"));
-    triggerEvent('#mobile', 'blur');
+    fillIn("#mobile", hk_user.get("mobile"));
+    triggerEvent("#mobile", "blur");
     click("#getsmscode");
   });
 
@@ -55,24 +58,24 @@ test("User is able to enter sms code and confirm and redirected to offers", func
   visit("/authenticate");
   andThen(function() {
     var ele_logout = $("a:contains('Logout')");
-    if(ele_logout.length > 0){
+    if (ele_logout.length > 0) {
       click(ele_logout[0]);
     }
   });
 
   andThen(function() {
-    visit('/authenticate');
-    fillIn('#pin', "1234");
-    triggerEvent('#pin', 'blur');
+    visit("/authenticate");
+    fillIn("#pin", "1234");
+    triggerEvent("#pin", "blur");
   });
 
   andThen(function() {
-    assert.equal(find('#pin').val().length, 4);
+    assert.equal(find("#pin").val().length, 4);
     window.localStorage.authToken = authToken;
     click("#submit_pin");
   });
 
-  andThen(function(){
+  andThen(function() {
     assert.equal(currentURL(), "/offers");
   });
 });
@@ -90,25 +93,27 @@ test("Logout clears authToken", function(assert) {
 test("User is able to resend the sms code", function(assert) {
   assert.expect(1);
 
-  $.mockjax({url:"/api/v1/auth/send_pi*",responseText:{
-    "otp_auth_key" : "/JqONEgEjrZefDV3ZIQsNA=="
-  }});
+  $.mockjax({
+    url: "/api/v1/auth/send_pi*",
+    responseText: {
+      otp_auth_key: "/JqONEgEjrZefDV3ZIQsNA=="
+    }
+  });
 
   visit("/authenticate");
   andThen(function() {
     var ele_logout = $("a:contains('Logout')");
-    if(ele_logout.length > 0){
+    if (ele_logout.length > 0) {
       click(ele_logout[0]);
     }
   });
 
   andThen(function() {
-    visit('/authenticate');
+    visit("/authenticate");
     click("#resend-pin");
   });
 
   andThen(function() {
     assert.equal(window.localStorage.otpAuthKey, '"/JqONEgEjrZefDV3ZIQsNA=="');
   });
-
 });

--- a/tests/acceptance/offer-test.js
+++ b/tests/acceptance/offer-test.js
@@ -1,42 +1,44 @@
-import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import FactoryGuy from 'ember-data-factory-guy';
-import TestHelper from 'ember-data-factory-guy/factory-guy-test-helper';
+import Ember from "ember";
+import startApp from "../helpers/start-app";
+import FactoryGuy from "ember-data-factory-guy";
+import TestHelper from "ember-data-factory-guy/factory-guy-test-helper";
 
 var App, store, offer, item1, item2, image;
 
-module('Display Offer', {
+module("Display Offer", {
   beforeEach: function() {
     App = startApp();
     TestHelper.setup();
     store = FactoryGuy.store;
 
     offer = FactoryGuy.make("offer");
-    item1 = FactoryGuy.make("item", {offer:offer,state:"submitted"});
-    item2 = FactoryGuy.make("item", {offer:offer,state:"submitted"});
-    image = FactoryGuy.make("image", {item:item1,favourite:true});
+    item1 = FactoryGuy.make("item", { offer: offer, state: "submitted" });
+    item2 = FactoryGuy.make("item", { offer: offer, state: "submitted" });
+    image = FactoryGuy.make("image", { item: item1, favourite: true });
   },
 
   afterEach: function() {
-    Em.run(function() { TestHelper.teardown(); });
-    Ember.run(App, 'destroy');
+    Em.run(function() {
+      TestHelper.teardown();
+    });
+    Ember.run(App, "destroy");
   }
 });
 
 test("Display offer details", function() {
-  visit('/offers/' + offer.id + "/offer_details");
+  visit("/offers/" + offer.id + "/offer_details");
 
   andThen(function() {
     // offer show page
     equal(currentURL(), "/offers/" + offer.id + "/offer_details");
-    equal($.trim(find('.tab-bar-section .title').text()), "Offer Details");
+    equal($.trim(find(".tab-bar-section .title").text()), "Offer Details");
 
     // add-item & remove-item buttons and confirm offer link
     // equal(find("a:contains('Add Item')").length, 1);
     equal(find("a[href='/offers/" + offer.id + "/confirm']").length, 1);
 
     // list of all items
-    equal(find('.item-content li img.cl-item-image').length, 2);
+    equal(find(".item-content li img.cl-item-image").length, 2);
 
     // favourite image for 'item2': default image
     equal(find('img[src="assets/images/default_item.jpg"]').length, 1);
@@ -46,12 +48,17 @@ test("Display offer details", function() {
   });
 });
 
-test("Confirm and Submit Offer", function(){
+test("Confirm and Submit Offer", function() {
   visit("/offers/" + offer.id + "/offer_details");
-  click("a[href='/offers/"+ offer.id +"/confirm']");
+  click("a[href='/offers/" + offer.id + "/confirm']");
 
   andThen(function() {
-    equal($('h1.title').text().toLowerCase(), "confirm");
+    equal(
+      $("h1.title")
+        .text()
+        .toLowerCase(),
+      "confirm"
+    );
     equal(currentURL(), "/offers/" + offer.id + "/confirm");
 
     // confirm offer page has submit link
@@ -60,11 +67,15 @@ test("Confirm and Submit Offer", function(){
     click("a:contains('Next')");
 
     andThen(function() {
-      equal($('h1.title').text().toLowerCase(), "sale of goods");
+      equal(
+        $("h1.title")
+          .text()
+          .toLowerCase(),
+        "sale of goods"
+      );
       equal(currentURL(), "/offers/" + offer.id + "/submit");
 
-
-      click("button:contains('Yes')");
+      click(".button.submit");
 
       andThen(function() {
         equal(currentURL(), "/offers/" + offer.id + "/offer_details");

--- a/yarn.lock
+++ b/yarn.lock
@@ -10339,7 +10339,7 @@ sha@~2.0.1:
 
 "shared-goodcity@git://github.com/crossroads/shared.goodcity.git#master":
   version "0.0.0"
-  resolved "git://github.com/crossroads/shared.goodcity.git#28c2bb73b4513810b831199fc9f539e9a22145a2"
+  resolved "git://github.com/crossroads/shared.goodcity.git#7f12addb009406f15261293d3735c1d955313cb8"
   dependencies:
     cryptiles "^4.1.2"
     ember-cli-babel "^5.1.6"


### PR DESCRIPTION
There were tests failing due to the latest changes of shared on donor app. 
As now we have removed the preload of offers from shared, peekAll wont work and it will always take the user to offer show page. Please see the `redirect` method in the `index.js` route. 

User is unable to goto the index page of `offers`. i.e. user is unable to view all his offers. 

So I've added findAll for the offers. so that donor can see his/her offers. Also fixed some of the old tests.

Will create a ticket in the next sprint to implement infinity scroll for offer load on the donor `/offers` page.

Please review.

Thanks