### PR TITLE
fix lodash defaults deep vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "js-yaml": "^3.13.1",
     "loader.js": "4.0.0",
     "lodash": "^4.17.13",
+    "lodash.defaultsdeep": "^4.6.1",
     "lodash.merge": "^4.6.2",
     "minimatch": "^3.0.2",
     "phantomjs-prebuilt": "^2.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7263,6 +7263,11 @@ lodash.defaultsdeep@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz#bec1024f85b1bd96cbea405b23c14ad6443a6f81"
   integrity sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=
 
+lodash.defaultsdeep@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz#512e9bd721d272d94e3d3a63653fa17516741ca6"
+  integrity sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==
+
 lodash.escape@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-2.3.0.tgz#844c38c58f844e1362ebe96726159b62cf5f2a58"


### PR DESCRIPTION
Hi Team,

This PR fixes vulnerability: https://github.com/crossroads/app.goodcity/network/alert/yarn.lock/lodash.defaultsdeep/open

I did smoke test on local and everything looks fine to me.

Please review.

Thanks.