### PR TITLE
GCW-3660 Fix loading of Offer Messages

### DIFF
--- a/app/routes/offer/messages.js
+++ b/app/routes/offer/messages.js
@@ -1,3 +1,13 @@
-import MessagesBaseRoute from 'shared-goodcity/routes/messages_base';
+import MessagesBaseRoute from "shared-goodcity/routes/messages_base";
+import Ember from "ember";
 
-export default MessagesBaseRoute;
+export default MessagesBaseRoute.extend({
+  model() {
+    return Ember.RSVP.Promise.all([
+      this.store.query("message", {
+        messageable_type: "Offer",
+        messageable_id: this.modelFor("offer").get("id")
+      })
+    ]);
+  }
+});


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3660

### What does this PR do?
When User directly visits the offer messages page or hot-reload offer messages page, it was not loading messages as messages are no longer part of offer response and hence need to be reloaded separately.